### PR TITLE
feat: Add frontend service to render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,5 +15,21 @@ services:
     region: oregon
     autoDeploy: true
 
+  - type: static_site
+    name: unhimas-frontend
+    plan: free
+    buildCommand: "npm install && npm run build"
+    staticPublishPath: "./dist"
+    routes:
+      - type: rewrite
+        source: "/*"
+        destination: "/index.html"
+    envVars:
+      - key: VITE_API_BASE_URL
+        fromService:
+          type: web_service
+          name: unhimas-backend
+          property: url
+
 
 # Render will build the Dockerfile located at `backend/Dockerfile` for the backend service.


### PR DESCRIPTION
The frontend and backend were not communicating in the production environment because the `VITE_API_BASE_URL` environment variable was not set for the frontend. This caused API requests to fail with a 404 error.

This commit adds a new service definition for the frontend to the `render.yaml` file. This new service is a `static_site` that builds the frontend and sets the `VITE_API_BASE_URL` environment variable to the URL of the backend service. This ensures that the frontend can correctly connect to the backend in the production environment deployed on Render.