### PR TITLE
Replace deprecated fields in render.yaml (env, root, autoDeploy) with…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,8 +3,8 @@
 services:
   - type: web
     name: unhimas-backend
-    env: docker
-    root: "backend"
+    runtime: docker
+    rootDir: "backend"
     plan: free
     envVars:
       - key: MONGO_URI
@@ -24,7 +24,7 @@ services:
           property: url
     healthCheckPath: "/api/health"
     region: oregon
-    autoDeploy: true
+    autoDeployTrigger: commit
 
   - type: web
     name: unhimas-frontend


### PR DESCRIPTION
… their modern equivalents (runtime, rootDir, autoDeployTrigger) to fix deployment errors.