### PR TITLE
Update render.yaml to construct service URLs manually using the _HOST…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,10 +18,7 @@ services:
       - key: NODE_ENV
         value: "production"
       - key: FRONTEND_ORIGIN
-        fromService:
-          type: web
-          name: unhimas-frontend
-          property: url
+        value: "https://${unhimas-frontend_HOST}"
     healthCheckPath: "/api/health"
     region: oregon
     autoDeployTrigger: commit
@@ -38,10 +35,7 @@ services:
         destination: "/index.html"
     envVars:
       - key: VITE_API_BASE_URL
-        fromService:
-          type: web
-          name: unhimas-backend
-          property: url
+        value: "https://${unhimas-backend_HOST}"
 
 
 # Render will build the Dockerfile located at `backend/Dockerfile` for the backend service.


### PR DESCRIPTION
… environment variable provided by Render. This fixes the 'invalid service property: url' error.