### PR TITLE
Remove hardcoded API base URL in fetchClient.ts and use the VITE_API_…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     name: unhimas-backend
     runtime: docker
     rootDir: "backend"
-    plan: free # ✅ allowed for backend
+    plan: free
     envVars:
       - key: MONGO_URI
         sync: false
@@ -26,6 +26,7 @@ services:
   - type: web
     name: unhimas-frontend
     runtime: static
+    plan: free
     buildCommand: "npm install && npm run build"
     staticPublishPath: "./dist"
     routes:
@@ -37,4 +38,4 @@ services:
         value: "https://unhimas-saas-wp25.onrender.com"
 
 
-# Render will build the Dockerfile located at `backend/Dockerfile` for th
+# Render will build the Dockerfile located at `backend/Dockerfile` for the backend service.

--- a/src/lib/fetchClient.ts
+++ b/src/lib/fetchClient.ts
@@ -1,5 +1,4 @@
 // Central API base for all frontend requests
-const API_BASE = 'https://unhimas-saas-wp25.onrender.com';
 export const getAuthToken = () => {
     try { return localStorage.getItem('token'); } catch (e) { return null; }
 };
@@ -12,8 +11,8 @@ const defaultHeaders = (extra?: Record<string, string>) => {
 };
 
 const getBase = () => {
-    // Prefer the explicit hardcoded API base
-    if (API_BASE) return API_BASE.replace(/\/$/, '');
+    const apiUrl = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '');
+    if (apiUrl) return apiUrl;
     // Dev fallback
     if ((import.meta as any)?.env?.DEV) return 'http://localhost:5000';
     // Same-origin last resort


### PR DESCRIPTION
…BASE_URL environment variable instead. This allows the backend URL to be configured via the render.yaml file.